### PR TITLE
Photo can now be drawn in different shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Outside of the `\socialinfo` wrapper you have to define the mandatory parameters
 \name{Christophe}{ROGER}
 
 % Define author's photo (optional)
-% Usage \photo{<diameter>}{<photo>}
+% Usage: \photo[<shape: circular, square>]{<diameter>}{<photo>}
+% The shape of the author's photo is circular by default.
 \photo{2.5cm}{darwiin}
 
 % Define author's tagline

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Outside of the `\socialinfo` wrapper you have to define the mandatory parameters
 \name{Christophe}{ROGER}
 
 % Define author's photo (optional)
-% Usage: \photo[<shape: circular, square>]{<diameter>}{<photo>}
+% Usage: \photo[<shape: circular, square, roundedsquare, squircle>]{<diameter>}{<photo>}
 % The shape of the author's photo is circular by default.
 \photo{2.5cm}{darwiin}
 

--- a/yaac-another-awesome-cv.cls
+++ b/yaac-another-awesome-cv.cls
@@ -73,6 +73,7 @@
 \RequirePackage{tikz}
 \RequirePackage[skins]{tcolorbox}
 \RequirePackage{fancyhdr}
+\RequirePackage{ifthen}
 
 
 \DeclareUnicodeCharacter{00E9}{\'{e}}
@@ -215,8 +216,9 @@
 \newcommand*{\tagline}[1]{\def\@tagline{#1}}
 
 % Define author's photo
-% Usage \photo{<diameter>}{<photo>}
-\newcommand{\photo}[2]{\def\@photo{#2}\def\@photodiameter{#1}}
+% Usage: \photo[<shape: circular, square>]{<diameter>}{<photo>}
+% The shape of the author's photo is circular by default.
+\newcommand{\photo}[3][circular]{\def\@photo{#3}\def\@photodiameter{#2}\def\@photoshape{#1}}
 
 % Render author's address
 % Usage: \address{<address>}
@@ -271,7 +273,13 @@
 }
 
 \newcommand\idphoto{
-  \tikz\path[fill overzoom image={\@photo}]circle[radius=0.5\linewidth];
+	\ifthenelse{\equal{\@photoshape}{square}}{
+		% Draw square photo
+		\tikz\path[fill overzoom image={\@photo}]rectangle(\linewidth,\linewidth);
+	}{
+		% Draw circular photp
+		\tikz\path[fill overzoom image={\@photo}]circle[radius=0.5\linewidth];
+	}
 }
 
 % Define social entries to print in header

--- a/yaac-another-awesome-cv.cls
+++ b/yaac-another-awesome-cv.cls
@@ -216,7 +216,7 @@
 \newcommand*{\tagline}[1]{\def\@tagline{#1}}
 
 % Define author's photo
-% Usage: \photo[<shape: circular, square>]{<diameter>}{<photo>}
+% Usage: \photo[<shape: circular, square, roundedsquare, squircle>]{<diameter>}{<photo>}
 % The shape of the author's photo is circular by default.
 \newcommand{\photo}[3][circular]{\def\@photo{#3}\def\@photodiameter{#2}\def\@photoshape{#1}}
 
@@ -277,8 +277,19 @@
 		% Draw square photo
 		\tikz\path[fill overzoom image={\@photo}]rectangle(\linewidth,\linewidth);
 	}{
-		% Draw circular photp
-		\tikz\path[fill overzoom image={\@photo}]circle[radius=0.5\linewidth];
+		\ifthenelse{\equal{\@photoshape}{roundedsquare}}{
+			% Draw square photo with rounded corners
+			\tikz\path[fill overzoom image={\@photo}][rounded corners=2mm]rectangle(\linewidth,\linewidth);
+		}{
+			\ifthenelse{\equal{\@photoshape}{squircle}}{
+				% Draw squircle photo
+				\tikz\path[fill overzoom image={\@photo}][rounded corners=8mm]rectangle(\linewidth,\linewidth);
+				}{
+					% Draw circular photo
+					\tikz\path[fill overzoom image={\@photo}]circle[radius=0.5\linewidth];
+				}
+		}
+
 	}
 }
 


### PR DESCRIPTION
# Description

Added the optional argument `[<shape>]` to the command `\photo` to either draw the photo circular, square, square with rounded corners or as a squircle. The default value is circular and thus `\photo` behaves exactly as before.

Fixes #19

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that the original example is succesfully built on circleci
