### PR TITLE
Added StackOverflow and StackExchange to list of social info accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Most social network have their command to render a clickable link or a simple te
 % Usage: \github{<github-nick>}
 \github{darwiin}
 
+% Render author's stackoverflow profile (optional)
+% Usage: \stackoverflow{<stackoverflow-user-id>}
+\stackoverflow{759643}
+
+% Render author's stackexchange profile (optional)
+% Usage: \stackexchange{<stackexchange-user-id>}
+\stackexchange{396216}
+
 % Render author's email (optional)
 % Usage: \email{<email adress>}
 \email{christophe.roger@mail.com}

--- a/yaac-another-awesome-cv.cls
+++ b/yaac-another-awesome-cv.cls
@@ -173,6 +173,8 @@
 \newcommand{\viadeoSymbol}{\faViadeo}
 \newcommand{\mobileSymbol}{\faMobile*}
 \newcommand{\githubSymbol}{\faGithub}
+\newcommand{\stackoverflowSymbol}{\faStackOverflow}
+\newcommand{\stackexchangeSymbol}{\faStackExchange}
 \newcommand{\mediumSymbol}{\faMedium}
 \newcommand{\bitbucketSymbol}{\faBitbucket}
 \newcommand{\websiteSymbol}{\faLink}
@@ -237,6 +239,14 @@
 % Render author's github (optional)
 % Usage: \github{<github-nick>}
 \newcommand*{\github}[1]{\sociallink{\githubSymbol}{https://www.github.com/#1}{github.com/#1}}           % Github icon + URL
+
+% Render author's stackoverflow profile (optional)
+% Usage: \stackoverflow{<stackoverflow-user-id>}
+\newcommand*{\stackoverflow}[1]{\sociallink{\stackoverflowSymbol}{https://www.stackoverflow.com/u/#1}{stackoverflow.com/u/#1}}
+
+% Render author's stackexchange profile (optional)
+% Usage: \stackexchange{<stackexchange-user-id>}
+\newcommand*{\stackexchange}[1]{\sociallink{\stackexchangeSymbol}{https://stackexchange.com/users/#1}{stackexchange.com/users/#1}}
 
 % Render author's medium (optional)
 % Usage: \medium{<medium-nick>}


### PR DESCRIPTION
# Description

Added StackOverflow and StackExchange to list of social info accounts.
For instance, the command `\stackoverflow{759643}` outputs the link [https://stackoverflow.com/u/759643](https://stackoverflow.com/u/759643) and the command `\stackexchange{396216}` outputs the link [https://stackexchange.com/users/396216](https://stackexchange.com/users/396216) with a corresponding icon in the social info section.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have checked that the original example is successfully built on CircleCI